### PR TITLE
Add stock info and reorganize product detail layout

### DIFF
--- a/client/pages/ProductDetail.tsx
+++ b/client/pages/ProductDetail.tsx
@@ -345,6 +345,22 @@ export default function ProductDetail() {
                     <span className="text-gray-600">Height:</span>
                     <span className="ml-2 font-medium">{product.height}</span>
                   </div>
+                  <div>
+                    <span className="text-gray-600">Availability:</span>
+                    <span
+                      className={`ml-2 font-medium ${product.in_stock ? "text-green-600" : "text-red-600"}`}
+                    >
+                      {product.in_stock ? "In Stock" : "Out of Stock"}
+                    </span>
+                  </div>
+                  {product.stockQuantity !== undefined && (
+                    <div>
+                      <span className="text-gray-600">Stock Quantity:</span>
+                      <span className="ml-2 font-medium">
+                        {product.stockQuantity}
+                      </span>
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/client/pages/ProductDetail.tsx
+++ b/client/pages/ProductDetail.tsx
@@ -117,7 +117,8 @@ export default function ProductDetail() {
   }
 
   const discountPercentage = Math.round(
-    (((product.mrp || 0) - (product.our_price || 0)) / (product.mrp || 1)) * 100,
+    (((product.mrp || 0) - (product.our_price || 0)) / (product.mrp || 1)) *
+      100,
   );
 
   const handleAddToCart = async () => {
@@ -395,6 +396,14 @@ export default function ProductDetail() {
                 </div>
               </div>
 
+              {/* Product Description */}
+              <div className="bg-white p-6 rounded-lg border">
+                <h3 className="font-medium text-gray-900 mb-4">Description</h3>
+                <p className="text-gray-600 leading-relaxed">
+                  {product.description}
+                </p>
+              </div>
+
               {/* Services */}
               <div className="grid grid-cols-3 gap-4">
                 <div className="text-center p-4 bg-white rounded-lg border">
@@ -403,24 +412,14 @@ export default function ProductDetail() {
                 </div>
                 <div className="text-center p-4 bg-white rounded-lg border">
                   <RotateCcw className="h-8 w-8 text-[#1690C7] mx-auto mb-2" />
-                  <p className="text-sm font-medium">Easy Returns</p>
+                  <p className="text-sm font-medium">Warranty</p>
                 </div>
                 <div className="text-center p-4 bg-white rounded-lg border">
                   <Shield className="h-8 w-8 text-[#1690C7] mx-auto mb-2" />
-                  <p className="text-sm font-medium">Warranty</p>
+                  <p className="text-sm font-medium">Easy Returns</p>
                 </div>
               </div>
             </div>
-          </div>
-
-          {/* Product Description */}
-          <div className="bg-white p-6 rounded-lg border mb-8">
-            <h2 className="text-xl font-bold text-gray-900 mb-4">
-              Description
-            </h2>
-            <p className="text-gray-600 leading-relaxed">
-              {product.description}
-            </p>
           </div>
 
           {/* FAQs */}


### PR DESCRIPTION
This change enhances the ProductDetail component with the following updates:

- Add availability status display showing "In Stock" or "Out of Stock" with color coding
- Add conditional stock quantity display when available
- Move product description section to appear earlier in the layout
- Reorder service icons: swap "Easy Returns" and "Warranty" positions
- Fix code formatting for discount percentage calculation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3278b000039d4b419b4a509c757df62a/zenith-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3278b000039d4b419b4a509c757df62a</projectId>-->
<!--<branchName>zenith-home</branchName>-->